### PR TITLE
Support trifecta-2.1

### DIFF
--- a/show-prettyprint.cabal
+++ b/show-prettyprint.cabal
@@ -22,7 +22,7 @@ library
                      , Text.Show.Prettyprint.Diagnostic
                      , Text.Show.Prettyprint.Internal
   build-depends:       base >= 4.7 && < 5
-                     , trifecta >= 1.6
+                     , trifecta >= 2.1
                      , prettyprinter >= 1.2
 
                      -- Transitive dep of Trifecta, figure it out via that one

--- a/src/Text/Show/Prettyprint/Diagnostic.hs
+++ b/src/Text/Show/Prettyprint/Diagnostic.hs
@@ -17,7 +17,6 @@ module Text.Show.Prettyprint.Diagnostic (
 
 
 
-import qualified Text.PrettyPrint.ANSI.Leijen as OldAnsiPpr
 import           Text.Trifecta                as Tri
 
 import Text.Show.Prettyprint.Internal
@@ -29,7 +28,7 @@ import Text.Show.Prettyprint.Internal
 prettifyShowErr :: String -> String
 prettifyShowErr s = case parseString shownP mempty s of
     Success x -> show x
-    Failure ErrInfo{ _errDoc = e } -> "ERROR " <> show (OldAnsiPpr.plain e)
+    Failure ErrInfo{ _errDoc = e } -> "ERROR " <> show e
 
 -- | 'prettifyShowErr' with the 'show' baked in.
 prettyShowErr :: Show a => a -> String

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,5 @@ packages:
     - '.'
 flags: {}
 extra-package-dbs: []
+extra-deps:
+  - trifecta-2.1


### PR DESCRIPTION
Fixes #7

`trifecta-2.1` uses `prettyprinter` as its pretty printer, so `ErrInfo` now contains a `prettyprinter` `Doc`. 