### PR TITLE
Fix build failure

### DIFF
--- a/show-prettyprint.cabal
+++ b/show-prettyprint.cabal
@@ -24,9 +24,6 @@ library
   build-depends:       base >= 4.7 && < 5
                      , trifecta >= 1.6
                      , prettyprinter >= 1.2
-
-                     -- Transitive dep of Trifecta, figure it out via that one
-                     , ansi-wl-pprint
   ghc-options:         -Wall
   default-language:    Haskell2010
 

--- a/show-prettyprint.cabal
+++ b/show-prettyprint.cabal
@@ -22,7 +22,7 @@ library
                      , Text.Show.Prettyprint.Diagnostic
                      , Text.Show.Prettyprint.Internal
   build-depends:       base >= 4.7 && < 5
-                     , trifecta >= 1.6
+                     , trifecta >= 2.1
                      , prettyprinter >= 1.2
   ghc-options:         -Wall
   default-language:    Haskell2010

--- a/src/Text/Show/Prettyprint/Diagnostic.hs
+++ b/src/Text/Show/Prettyprint/Diagnostic.hs
@@ -3,12 +3,10 @@
 -- failure.
 --
 -- >>> putStrLn (prettifyShowErr "Imbalanced (Parenthesis)) here")
--- ERROR (interactive):1:25: error: expected: char literal,
---     end of input, identifier, list,
---     number, record, string literal,
---     tuple, unit
--- Imbalanced (Parenthesis)) here<EOF>
---                         ^
+-- ERROR (interactive):1:25: error: expected: char literal, end of input, identifier,
+--     list, number, record, string literal, tuple, unit
+-- 1 | Imbalanced (Parenthesis)) here<EOF> 
+--   |                         ^           
 module Text.Show.Prettyprint.Diagnostic (
     prettifyShowErr,
     prettyShowErr,

--- a/src/Text/Show/Prettyprint/Diagnostic.hs
+++ b/src/Text/Show/Prettyprint/Diagnostic.hs
@@ -17,11 +17,10 @@ module Text.Show.Prettyprint.Diagnostic (
 
 
 
-import qualified Text.PrettyPrint.ANSI.Leijen as OldAnsiPpr
+import           Data.Text.Prettyprint.Doc    as Doc
 import           Text.Trifecta                as Tri
 
 import Text.Show.Prettyprint.Internal
-
 
 
 -- | Attempt to prettify a string produced by 'show'. Report error information
@@ -29,7 +28,7 @@ import Text.Show.Prettyprint.Internal
 prettifyShowErr :: String -> String
 prettifyShowErr s = case parseString shownP mempty s of
     Success x -> show x
-    Failure ErrInfo{ _errDoc = e } -> "ERROR " <> show (OldAnsiPpr.plain e)
+    Failure ErrInfo{ _errDoc = e } -> "ERROR " <> show (Doc.unAnnotate e)
 
 -- | 'prettifyShowErr' with the 'show' baked in.
 prettyShowErr :: Show a => a -> String

--- a/src/Text/Show/Prettyprint/Internal.hs
+++ b/src/Text/Show/Prettyprint/Internal.hs
@@ -27,11 +27,11 @@ import Text.Trifecta             as Tri
 
 -- $setup
 --
--- >>> import Text.PrettyPrint.ANSI.Leijen (plain)
+-- >>> import Data.Text.Prettyprint.Doc (unAnnotate)
 -- >>> :{
 -- let testParse p s = case parseString p mempty s of
 --         Success x -> print x
---         Failure ErrInfo{ _errDoc = e } -> putStrLn ("ERROR " ++ show (plain e))
+--         Failure ErrInfo{ _errDoc = e } -> putStrLn ("ERROR " ++ show (unAnnotate e))
 -- :}
 
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,5 @@ packages:
     - '.'
 flags: {}
 extra-package-dbs: []
+extra-deps:
+- trifecta-2.1@sha256:34c69c2f80b370c81f17bb55ee2ed0b61530cb48338f7a81b0cd95653e9b8325,3966

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,14 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: trifecta-2.1@sha256:34c69c2f80b370c81f17bb55ee2ed0b61530cb48338f7a81b0cd95653e9b8325,3966
+    pantry-tree:
+      size: 1832
+      sha256: 5d23fffe86a418999eeff2e868b34ec0e39e05c469d6558ec41bd565d8c52f93
+  original:
+    hackage: trifecta-2.1@sha256:34c69c2f80b370c81f17bb55ee2ed0b61530cb48338f7a81b0cd95653e9b8325,3966
 snapshots:
 - completed:
     size: 498186


### PR DESCRIPTION
Fixes #7.

The type of `trifecta`'s `_errDoc` was previously a `Doc` from `ansi-wl-pprint`. Now it's a `Doc` with annotations from `prettyprinter-ansi-terminal`.